### PR TITLE
Fixed issue with token-containing paths and ensureSignedIn

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -96,7 +96,7 @@ AccountsTemplates.configureRoute = function(route, options) {
   this.routes[route] = options;
 
   // Known routes are used to filter out previous path for redirects...
-  AccountsTemplates.knownRoutes.push(options.path);
+  AccountsTemplates.knownRoutes.push(options.name);
 
   if (Meteor.isServer) {
     // Configures "reset password" email link


### PR DESCRIPTION
ensureSignedIn was using the path to check against knownPaths to exclude, but when the path contained a token, it wasn't matching.  This change switches to match on route name instead.
