### PR TITLE
Fixed issue with token-containing paths and ensureSignedIn

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -52,7 +52,7 @@ AccountsTemplates.setPrevPath = function(newPath) {
 AccountsTemplates.ensureSignedIn = function(context, redirect) {
   if (!Meteor.userId()) {
     // if we're not already on an AT route
-    if (!_.contains(AccountsTemplates.knownRoutes, context.path)) {
+    if (!_.contains(AccountsTemplates.knownRoutes, context.route.name)) {
 
       AccountsTemplates.setState(AccountsTemplates.options.defaultState, function() {
         var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
@@ -73,11 +73,11 @@ AccountsTemplates.ensureSignedIn = function(context, redirect) {
 // Stores previous path on path change...
 FlowRouter.triggers.enter([
   function(context) {
-    var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(path) {
-      if (!path) {
+    var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(route) {
+      if (!route) {
         return false;
       }
-      var known = RegExp(path).test(context.path);
+      var known = RegExp(route).test(context.route.name);
       return known;
     });
     if (!_.some(isKnownRoute)) {


### PR DESCRIPTION
ensureSignedIn was using the path to check against knownPaths to exclude, but when the path contained a token, it wasn't matching.  This change switches to match on route name instead.
